### PR TITLE
Update options in README to match what's in the GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ Maintainers: [sherakama](https://github.com/sherakama), [jbickar](https://github
 
 This module provides a content type that supports dynamic layouts. With multiple view modes, site builders can choose which layout they want to use on a per-node basis. Included view modes are:
 
-* Large Landscape
-* Blocks
 * List
-* Titles only
+* Blocks
+* Cards
 
 Additional included modules
 ---


### PR DESCRIPTION
I'm not sure where "Large Landscape" or "Titles only" came from.
